### PR TITLE
fix: :ambulance: fixed crash issue on proxy delete

### DIFF
--- a/internal/cmdProxy/cmdProxy.go
+++ b/internal/cmdProxy/cmdProxy.go
@@ -199,10 +199,11 @@ func createCmdProxy(c *gin.Context) {
 		if err := client.handShake(); err != nil {
 
 			reqClientMapMutex.Lock()
+			if _, exist := reqClientMap[endpoint.NickName]; exist {
+				client.socket.Close()
 			delete(reqClientMap, endpoint.NickName)
+			}
 			reqClientMapMutex.Unlock()
-
-			client.socket.Close()
 		}
 	}()
 


### PR DESCRIPTION
fixed the issue that calling the delete endpoint before the handshake is completed would cause a crash