### PR TITLE
feat: :sparkles: make server port configurable

### DIFF
--- a/cmd/service.go
+++ b/cmd/service.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"log/slog"
 	"os"
 	"os/user"
@@ -166,11 +167,12 @@ func Serve() {
 	obs.RegisterRoutes(api)
 	email.RegisterRoutes(api)
 
-	err := r.Run(":9012")
+	addr := fmt.Sprintf(":%d", Config.Port)
+	err := r.Run(addr)
 	if err != nil {
-		logger.Logger.Error("failed to start server", "port", 9012, "error", err)
+		logger.Logger.Error("failed to start server", "port", Config.Port, "error", err)
 		logger.Logger.Error("failed to start cogmoteGO: ",
-			slog.Int("port", 9012),
+			slog.Int("port", Config.Port),
 			slog.String("error", err.Error()),
 		)
 		os.Exit(1)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,6 +25,7 @@ type ProxyConfig struct {
 }
 
 type Config struct {
+	Port       int         `mapstructure:"port"`
 	InstanceID string      `mapstructure:"instance_id"`
 	Email      EmailConfig `mapstructure:"email"`
 	Proxy      ProxyConfig `mapstructure:"proxy"`
@@ -37,6 +38,8 @@ func LoadConfig(cfgFile string) Config {
 	viper.SetDefault("email.smtp_host", "")
 	viper.SetDefault("email.smtp_port", 0)
 	viper.SetDefault("email.recipients", []string{})
+
+	viper.SetDefault("port", 9012)
 
 	viper.SetDefault("instance_id", "")
 


### PR DESCRIPTION
- Add Port field to Config struct with default value 9012
- Update server startup to use configured port instead of hardcoded value
- Update error logging to use configured port