### PR TITLE
fix(ci): :green_heart: add release-please to upload-release job dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,7 @@ jobs:
           retention-days: 1
 
   upload-release:
-    needs: build
+    needs: [release-please, build]
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
The upload-release job was unable to access tag_name from release-please because it only depended on build job. This caused "GitHub Releases requires a tag" error.