### PR TITLE
refactor(obs): :recycle: improve OBS configuration and init logic

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -77,6 +77,32 @@ var configFields = []configField{
 		description:  "Retry interval (ms)",
 		group:        "Proxy",
 	},
+	{
+		key:          "obs.scene_name",
+		fieldType:    "string",
+		defaultValue: "cagelab",
+		validate: func(v string) error {
+			if v == "" {
+				return fmt.Errorf("scene_name cannot be empty")
+			}
+			return nil
+		},
+		description: "OBS scene name",
+		group:       "OBS",
+	},
+	{
+		key:          "obs.source_name",
+		fieldType:    "string",
+		defaultValue: "cogmoteGO",
+		validate: func(v string) error {
+			if v == "" {
+				return fmt.Errorf("source_name cannot be empty")
+			}
+			return nil
+		},
+		description: "OBS text source name",
+		group:       "OBS",
+	},
 }
 
 func findConfigField(key string) *configField {

--- a/cmd/obs.go
+++ b/cmd/obs.go
@@ -1,0 +1,116 @@
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/Ccccraz/cogmoteGO/internal/keyring"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"golang.org/x/term"
+)
+
+var obsCmd = &cobra.Command{
+	Use:   "obs",
+	Short: "Manage OBS configuration",
+	Long:  "Manage OBS scene/source settings and password stored in the system keyring.",
+}
+
+var obsSetCmd = &cobra.Command{
+	Use:   "set",
+	Short: "Set OBS configuration interactively",
+	Long:  "Interactively set scene name, source name, and password (password stored in keyring).",
+	Run: func(cmd *cobra.Command, args []string) {
+		reader := bufio.NewReader(os.Stdin)
+
+		currentSceneName := viper.GetString("obs.scene_name")
+		currentSourceName := viper.GetString("obs.source_name")
+
+		fmt.Printf("Enter scene name [%s]: ", currentSceneName)
+		sceneName, _ := reader.ReadString('\n')
+		sceneName = strings.TrimSpace(sceneName)
+		if sceneName == "" {
+			sceneName = currentSceneName
+		}
+
+		fmt.Printf("Enter source name [%s]: ", currentSourceName)
+		sourceName, _ := reader.ReadString('\n')
+		sourceName = strings.TrimSpace(sourceName)
+		if sourceName == "" {
+			sourceName = currentSourceName
+		}
+
+		if sceneName == sourceName {
+			fmt.Fprintln(os.Stderr, "error: scene_name and source_name cannot be the same (OBS limitation)")
+			return
+		}
+
+		fmt.Print("Enter password (will be stored in keyring): ")
+		passwordBytes, err := term.ReadPassword(int(os.Stdin.Fd()))
+		fmt.Println()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to read password: %v\n", err)
+			return
+		}
+		password := strings.TrimSpace(string(passwordBytes))
+
+		viper.Set("obs.scene_name", sceneName)
+		viper.Set("obs.source_name", sourceName)
+
+		if err := writeConfigWithFallback(); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to save configuration: %v\n", err)
+			return
+		}
+
+		if password != "" {
+			if err := keyring.SaveObsPassword(password); err != nil {
+				fmt.Fprintf(os.Stderr, "failed to store password in keyring: %v\n", err)
+				return
+			}
+		}
+
+		fmt.Println("OBS configuration saved")
+	},
+}
+
+var obsShowCmd = &cobra.Command{
+	Use:   "show",
+	Short: "Show current OBS configuration",
+	Long:  "Display the current OBS configuration. Password is not shown, only whether it is configured.",
+	Run: func(cmd *cobra.Command, args []string) {
+		sceneName := viper.GetString("obs.scene_name")
+		sourceName := viper.GetString("obs.source_name")
+
+		fmt.Println("OBS Configuration:")
+		fmt.Printf("  Scene name  : %s\n", valueOrNotSet(sceneName))
+		fmt.Printf("  Source name : %s\n", valueOrNotSet(sourceName))
+
+		if _, err := keyring.GetObsPassword(); err == nil {
+			fmt.Printf("  Password    : configured\n")
+		} else {
+			fmt.Printf("  Password    : not configured\n")
+		}
+	},
+}
+
+var obsDeletePasswordCmd = &cobra.Command{
+	Use:   "delete-password",
+	Short: "Delete OBS password from keyring",
+	Long:  "Remove the OBS password from the system keyring. Scene and source settings are preserved.",
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := keyring.DeleteObsPassword(); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to delete password: %v\n", err)
+			return
+		}
+		fmt.Println("OBS password deleted from system keyring")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(obsCmd)
+	obsCmd.AddCommand(obsSetCmd)
+	obsCmd.AddCommand(obsShowCmd)
+	obsCmd.AddCommand(obsDeletePasswordCmd)
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,11 +24,17 @@ type ProxyConfig struct {
 	RetryInterval    int `mapstructure:"retry_interval"`
 }
 
+type ObsConfig struct {
+	SceneName  string `mapstructure:"scene_name"`
+	SourceName string `mapstructure:"source_name"`
+}
+
 type Config struct {
 	Port       int         `mapstructure:"port"`
 	InstanceID string      `mapstructure:"instance_id"`
 	Email      EmailConfig `mapstructure:"email"`
 	Proxy      ProxyConfig `mapstructure:"proxy"`
+	Obs        ObsConfig   `mapstructure:"obs"`
 }
 
 func LoadConfig(cfgFile string) Config {
@@ -47,6 +53,9 @@ func LoadConfig(cfgFile string) Config {
 	viper.SetDefault("proxy.msg_timeout", 5000)
 	viper.SetDefault("proxy.max_retries", 3)
 	viper.SetDefault("proxy.retry_interval", 200)
+
+	viper.SetDefault("obs.scene_name", "cagelab")
+	viper.SetDefault("obs.source_name", "cogmoteGO")
 
 	configPath := cfgFile
 

--- a/internal/keyring/keyring.go
+++ b/internal/keyring/keyring.go
@@ -6,7 +6,10 @@ import (
 	"github.com/zalando/go-keyring"
 )
 
-const ServiceName = "cogmoteGO"
+const (
+	ServiceName    = "cogmoteGO"
+	ObsKeyringUser = "obs_password"
+)
 
 func SaveCredentials(username, password string) error {
 	if username == "" || password == "" {
@@ -21,4 +24,19 @@ func GetPassword(username string) (string, error) {
 
 func DeleteCredentials(username string) error {
 	return keyring.Delete(ServiceName, username)
+}
+
+func SaveObsPassword(password string) error {
+	if password == "" {
+		return fmt.Errorf("password cannot be empty")
+	}
+	return keyring.Set(ServiceName, ObsKeyringUser, password)
+}
+
+func GetObsPassword() (string, error) {
+	return keyring.Get(ServiceName, ObsKeyringUser)
+}
+
+func DeleteObsPassword() error {
+	return keyring.Delete(ServiceName, ObsKeyringUser)
 }

--- a/internal/obs/README.md
+++ b/internal/obs/README.md
@@ -1,0 +1,108 @@
+# OBS Integration
+
+[中文文档](./README.zh_cn.md)
+
+Integration module between cogmoteGO and OBS Studio for overlaying experiment data text on live streams.
+
+## Prerequisites
+
+1. Install OBS Studio (28.0+)
+2. Enable OBS WebSocket server:
+   - `Tools` → `WebSocket Server Settings`
+   - Port: `4455`
+   - Enable authentication and set a password
+
+## Configuration
+
+### CLI Configuration
+
+```bash
+# Interactive configuration for scene, source, and password
+cogmoteGO obs set
+
+# View current configuration status
+cogmoteGO obs show
+
+# Delete saved password
+cogmoteGO obs delete-password
+```
+
+### Docker Environment
+
+Pass password via environment variable:
+
+```bash
+docker run -e OBS_PASSWORD=yourpassword ...
+```
+
+## API Endpoints
+
+### Status
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/obs` | Get OBS status (version, streaming state) |
+
+### Initialization
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/api/obs/init` | Initialize OBS client connection |
+
+### Streaming Control
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/api/obs/start` | Start streaming |
+| POST | `/api/obs/stop` | Stop streaming |
+
+### Data Overlay
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/api/obs/data` | Update overlay text data |
+
+## Usage Flow
+
+```
+1. Start OBS and ensure WebSocket server is running
+2. Call POST /api/obs/init to initialize connection
+3. Call POST /api/obs/start to start streaming
+4. Call POST /api/obs/data to update experiment data
+5. Call POST /api/obs/stop to stop streaming
+```
+
+## Init Response Example
+
+```json
+{
+  "scene_name": "Scene",
+  "source_name": "overlay_text",
+  "scene_fallback": false,
+  "source_created": true
+}
+```
+
+- `scene_fallback`: First scene used when configured scene doesn't exist
+- `source_created`: Text source was newly created
+
+## Data Format
+
+POST `/api/obs/data` request body:
+
+```json
+{
+  "monkey_name": "monkey_001",
+  "trial_id": 42,
+  "start_time": "2024-01-15 10:30:00",
+  "correct_rate": 0.85
+}
+```
+
+Overlay text format: `{hostname} {monkey_name} {trial_id} {correct_rate}% {start_time}`
+
+## Notes
+
+- Scene and Source cannot share the same name
+- Text source is automatically positioned at the bottom of the screen (1920x1080 assumed)
+- Only supports local OBS connection (`localhost:4455`)

--- a/internal/obs/README.zh_cn.md
+++ b/internal/obs/README.zh_cn.md
@@ -1,0 +1,108 @@
+# OBS 集成
+
+[English](./README.md)
+
+cogmoteGO 与 OBS Studio 的集成模块，用于在直播画面上叠加实验数据文本。
+
+## 前置要求
+
+1. 安装 OBS Studio (28.0+)
+2. 启用 OBS WebSocket 服务器：
+   - `工具` → `WebSocket 服务器设置`
+   - 端口：`4455`
+   - 启用认证并设置密码
+
+## 配置
+
+### CLI 配置
+
+```bash
+# 交互式配置 scene、source 和密码
+cogmoteGO obs set
+
+# 查看当前配置状态
+cogmoteGO obs show
+
+# 删除保存的密码
+cogmoteGO obs delete-password
+```
+
+### Docker 环境
+
+使用环境变量传递密码：
+
+```bash
+docker run -e OBS_PASSWORD=yourpassword ...
+```
+
+## API 端点
+
+### 状态查询
+
+| 方法 | 路径 | 说明 |
+|------|------|------|
+| GET | `/api/obs` | 获取 OBS 状态 (版本、是否直播中) |
+
+### 初始化
+
+| 方法 | 路径 | 说明 |
+|------|------|------|
+| POST | `/api/obs/init` | 初始化 OBS 客户端连接 |
+
+### 直播控制
+
+| 方法 | 路径 | 说明 |
+|------|------|------|
+| POST | `/api/obs/start` | 开始直播 |
+| POST | `/api/obs/stop` | 停止直播 |
+
+### 数据叠加
+
+| 方法 | 路径 | 说明 |
+|------|------|------|
+| POST | `/api/obs/data` | 更新叠加文本数据 |
+
+## 使用流程
+
+```
+1. 启动 OBS 并确保 WebSocket 服务器运行
+2. 调用 POST /api/obs/init 初始化连接
+3. 调用 POST /api/obs/start 开始直播
+4. 调用 POST /api/obs/data 更新实验数据
+5. 调用 POST /api/obs/stop 停止直播
+```
+
+## Init 响应示例
+
+```json
+{
+  "scene_name": "Scene",
+  "source_name": "overlay_text",
+  "scene_fallback": false,
+  "source_created": true
+}
+```
+
+- `scene_fallback`: 配置的 scene 不存在时使用第一个 scene
+- `source_created`: 文本源是新创建的
+
+## 数据格式
+
+POST `/api/obs/data` 请求体：
+
+```json
+{
+  "monkey_name": "monkey_001",
+  "trial_id": 42,
+  "start_time": "2024-01-15 10:30:00",
+  "correct_rate": 0.85
+}
+```
+
+叠加文本格式：`{hostname} {monkey_name} {trial_id} {correct_rate}% {start_time}`
+
+## 注意事项
+
+- Scene 和 Source 不能使用相同名称
+- 文本源会自动定位在画面底部 (1920x1080 假设)
+- 仅支持连接本地 OBS (`localhost:4455`)

--- a/internal/obs/obs.go
+++ b/internal/obs/obs.go
@@ -3,24 +3,36 @@ package obs
 import (
 	"fmt"
 	"net/http"
+	"os"
 	"runtime"
+	"strings"
 
 	"github.com/Ccccraz/cogmoteGO/internal/commonTypes"
+	"github.com/Ccccraz/cogmoteGO/internal/keyring"
 	"github.com/andreykaipov/goobs"
 	"github.com/andreykaipov/goobs/api/requests/general"
 	"github.com/andreykaipov/goobs/api/requests/inputs"
 	"github.com/andreykaipov/goobs/api/requests/sceneitems"
+	"github.com/andreykaipov/goobs/api/requests/scenes"
 	"github.com/andreykaipov/goobs/api/requests/stream"
 	"github.com/andreykaipov/goobs/api/typedefs"
 
 	"github.com/gin-gonic/gin"
 	"github.com/shirou/gopsutil/v4/host"
+	"github.com/spf13/viper"
 )
 
 // ObsStatus represents basic OBS server info.
 type ObsStatus struct {
 	ObsVersion string `json:"obs_version"`
 	Streaming  bool   `json:"streaming"`
+}
+
+type InitObsResponse struct {
+	SceneName     string `json:"scene_name"`
+	SourceName    string `json:"source_name"`
+	SceneFallback bool   `json:"scene_fallback"`
+	SourceCreated bool   `json:"source_created"`
 }
 
 // obsData is the input payload for /obs/data
@@ -33,11 +45,18 @@ type obsData struct {
 
 var client *goobs.Client
 
-// Default OBS text source name
-const obsTextSource = "cogmoteGO"
-const obsSence = "cagelab"
-
 func strPtr(s string) *string { return &s }
+
+func loadObsPassword() string {
+	if password := strings.TrimSpace(os.Getenv("OBS_PASSWORD")); password != "" {
+		return password
+	}
+	password, err := keyring.GetObsPassword()
+	if err != nil {
+		return ""
+	}
+	return password
+}
 
 // getDeviceName automatically retrieves hostname via gopsutil
 func getDeviceName() string {
@@ -48,102 +67,156 @@ func getDeviceName() string {
 	return hostInfo.Hostname
 }
 
-// Initialize OBS client
-func InitObsClient() error {
+func InitObsClient() (*InitObsResponse, error) {
+	configSceneName := viper.GetString("obs.scene_name")
+	sourceName := viper.GetString("obs.source_name")
+
+	var opts []goobs.Option
+	if password := loadObsPassword(); password != "" {
+		opts = append(opts, goobs.WithPassword(password))
+	}
+
 	var err error
-	client, err = goobs.New("localhost:4455") // add goobs.WithPassword("xxx") if needed
+	client, err = goobs.New("localhost:4455", opts...)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	// Check if obsTextSource exists
-	inputsList, err := client.Inputs.GetInputList()
+	sceneListResp, err := client.Scenes.GetSceneList(&scenes.GetSceneListParams{})
 	if err != nil {
-		return fmt.Errorf("failed to get input list: %w", err)
+		return nil, fmt.Errorf("failed to get scene list: %w", err)
 	}
 
-	exists := false
-	for _, input := range inputsList.Inputs {
-		if input.InputName == obsTextSource {
-			exists = true
+	if len(sceneListResp.Scenes) == 0 {
+		return nil, fmt.Errorf("no scenes found in OBS")
+	}
+
+	var sceneName string
+	var sceneFallback bool
+	for _, s := range sceneListResp.Scenes {
+		if s.SceneName == configSceneName {
+			sceneName = configSceneName
+			sceneFallback = false
 			break
 		}
 	}
+	if sceneName == "" {
+		sceneName = sceneListResp.Scenes[0].SceneName
+		sceneFallback = true
+	}
 
-	if !exists {
-		data := obsData{
-			MonkeyName:  "unknown",
-			TrialID:     0,
-			StartTime:   "unknown",
-			CorrectRate: 0,
-		}
+	if sceneName == sourceName {
+		return nil, fmt.Errorf("scene_name and source_name cannot be the same (both are '%s'): OBS does not allow a source to have the same name as a scene", sceneName)
+	}
 
-		formatted := fmt.Sprintf(
-			"%s %s %d %.2f%% %s",
-			getDeviceName(),
-			data.MonkeyName,
-			data.TrialID,
-			data.CorrectRate*100,
-			data.StartTime,
-		)
+	sceneItems, err := client.SceneItems.GetSceneItemList(&sceneitems.GetSceneItemListParams{
+		SceneName: strPtr(sceneName),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get scene item list: %w", err)
+	}
 
-		var inputKind string
-		switch runtime.GOOS {
-		case "windows":
-			inputKind = "text_gdiplus"
-		case "linux", "darwin":
-			inputKind = "text_ft2_source_v2"
-		default:
-			return fmt.Errorf("unsupported platform: %s", runtime.GOOS)
-		}
-
-		// Create input
-		createResp, err := client.Inputs.CreateInput(&inputs.CreateInputParams{
-			SceneName: strPtr(obsSence),
-			InputName: strPtr(obsTextSource),
-			InputKind: strPtr(inputKind),
-			InputSettings: map[string]any{
-				"text": formatted,
-			},
-		})
-		if err != nil {
-			return fmt.Errorf("failed to create input %s: %w", obsTextSource, err)
-		}
-
-		// Resize and position the source
-		_, err = client.SceneItems.SetSceneItemTransform(&sceneitems.SetSceneItemTransformParams{
-			SceneName:   strPtr(obsSence),
-			SceneItemId: &createResp.SceneItemId,
-			SceneItemTransform: &typedefs.SceneItemTransform{
-				PositionX:       0.0,
-				PositionY:       1080.0,
-				ScaleX:          1,
-				ScaleY:          1,
-				Alignment:       9, // center alignment
-				BoundsType:      "OBS_BOUNDS_SCALE_TO_HEIGHT",
-				BoundsWidth:     1600.0,
-				BoundsHeight:    60.0,
-				BoundsAlignment: 9,
-			},
-		})
-		if err != nil {
-			return fmt.Errorf("failed to set scene item transform: %w", err)
+	for _, item := range sceneItems.SceneItems {
+		if item.SourceName == sourceName {
+			return &InitObsResponse{
+				SceneName:     sceneName,
+				SourceName:    sourceName,
+				SceneFallback: sceneFallback,
+				SourceCreated: false,
+			}, nil
 		}
 	}
 
-	return nil
+	data := obsData{
+		MonkeyName:  "unknown",
+		TrialID:     0,
+		StartTime:   "unknown",
+		CorrectRate: 0,
+	}
+
+	formatted := fmt.Sprintf(
+		"%s %s %d %.2f%% %s",
+		getDeviceName(),
+		data.MonkeyName,
+		data.TrialID,
+		data.CorrectRate*100,
+		data.StartTime,
+	)
+
+	var inputKind string
+	switch runtime.GOOS {
+	case "windows":
+		inputKind = "text_gdiplus"
+	case "linux", "darwin":
+		inputKind = "text_ft2_source_v2"
+	default:
+		return nil, fmt.Errorf("unsupported platform: %s", runtime.GOOS)
+	}
+
+	var sceneItemId int
+
+	createResp, err := client.Inputs.CreateInput(&inputs.CreateInputParams{
+		SceneName: strPtr(sceneName),
+		InputName: strPtr(sourceName),
+		InputKind: strPtr(inputKind),
+		InputSettings: map[string]any{
+			"text": formatted,
+		},
+	})
+	if err != nil {
+		if !strings.Contains(err.Error(), "ResourceAlreadyExists") {
+			return nil, fmt.Errorf("failed to create input %s: %w", sourceName, err)
+		}
+
+		createItemResp, err := client.SceneItems.CreateSceneItem(&sceneitems.CreateSceneItemParams{
+			SceneName:  strPtr(sceneName),
+			SourceName: strPtr(sourceName),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to add source %s to scene %s: %w", sourceName, sceneName, err)
+		}
+		sceneItemId = createItemResp.SceneItemId
+	} else {
+		sceneItemId = createResp.SceneItemId
+	}
+
+	_, err = client.SceneItems.SetSceneItemTransform(&sceneitems.SetSceneItemTransformParams{
+		SceneName:   strPtr(sceneName),
+		SceneItemId: &sceneItemId,
+		SceneItemTransform: &typedefs.SceneItemTransform{
+			PositionX:       0.0,
+			PositionY:       1080.0,
+			ScaleX:          1,
+			ScaleY:          1,
+			Alignment:       9,
+			BoundsType:      "OBS_BOUNDS_SCALE_TO_HEIGHT",
+			BoundsWidth:     1600.0,
+			BoundsHeight:    60.0,
+			BoundsAlignment: 9,
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to set scene item transform: %w", err)
+	}
+
+	return &InitObsResponse{
+		SceneName:     sceneName,
+		SourceName:    sourceName,
+		SceneFallback: sceneFallback,
+		SourceCreated: true,
+	}, nil
 }
 
-// HTTP handler: Initialize OBS connection
 func InitObsHandler(c *gin.Context) {
-	if err := InitObsClient(); err != nil {
+	resp, err := InitObsClient()
+	if err != nil {
 		c.JSON(http.StatusInternalServerError, commonTypes.APIError{
 			Error:  "failed to initialize OBS client",
 			Detail: err.Error(),
 		})
 		return
 	}
-	c.Status(http.StatusCreated)
+	c.JSON(http.StatusCreated, resp)
 }
 
 // HTTP handler: Get OBS status
@@ -226,7 +299,6 @@ func PostStopObsStreamingHandler(c *gin.Context) {
 	c.Status(http.StatusCreated)
 }
 
-// HTTP handler: Update OBS text source with experiment data
 func PostObsDataHandler(c *gin.Context) {
 	if client == nil {
 		c.JSON(http.StatusInternalServerError, commonTypes.APIError{
@@ -245,7 +317,6 @@ func PostObsDataHandler(c *gin.Context) {
 		return
 	}
 
-	// Simplified plain data string
 	formatted := fmt.Sprintf(
 		"%s %s %d %.2f%% %s",
 		getDeviceName(),
@@ -255,8 +326,9 @@ func PostObsDataHandler(c *gin.Context) {
 		req.StartTime,
 	)
 
+	sourceName := viper.GetString("obs.source_name")
 	_, err := client.Inputs.SetInputSettings(&inputs.SetInputSettingsParams{
-		InputName: strPtr(obsTextSource),
+		InputName: strPtr(sourceName),
 		InputSettings: map[string]any{
 			"text": formatted,
 		},


### PR DESCRIPTION
- Add ObsConfig struct and CLI commands (obs set/show/delete-password)
- Store password in keyring (CLI) or OBS_PASSWORD env var (Docker)
- Refactor InitObsClient to return scene/source selection info
- Add scene fallback: use first scene if configured scene not found
- Add bilingual README documentation with cross-references