### PR TITLE
feat(obs): :sparkles: add OBS application control endpoints (#171)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,8 +25,9 @@ type ProxyConfig struct {
 }
 
 type ObsConfig struct {
-	SceneName  string `mapstructure:"scene_name"`
-	SourceName string `mapstructure:"source_name"`
+	SceneName     string `mapstructure:"scene_name"`
+	SourceName    string `mapstructure:"source_name"`
+	InstallMethod string `mapstructure:"install_method"`
 }
 
 type Config struct {
@@ -56,6 +57,7 @@ func LoadConfig(cfgFile string) Config {
 
 	viper.SetDefault("obs.scene_name", "cagelab")
 	viper.SetDefault("obs.source_name", "cogmoteGO")
+	viper.SetDefault("obs.install_method", "system")
 
 	configPath := cfgFile
 

--- a/internal/obs/README.md
+++ b/internal/obs/README.md
@@ -17,8 +17,11 @@ Integration module between cogmoteGO and OBS Studio for overlaying experiment da
 ### CLI Configuration
 
 ```bash
-# Interactive configuration for scene, source, and password
+# Interactive configuration for scene, source, and install method
 cogmoteGO obs set
+
+# Set websocket password (stored in system keyring)
+cogmoteGO obs set-password
 
 # View current configuration status
 cogmoteGO obs show
@@ -26,6 +29,13 @@ cogmoteGO obs show
 # Delete saved password
 cogmoteGO obs delete-password
 ```
+
+### Install Method
+
+Supported install methods:
+
+- `system`: OBS installed via system package manager (default)
+- `flatpak`: OBS installed via Flatpak (`flatpak install com.obsproject.Studio`)
 
 ### Docker Environment
 
@@ -39,37 +49,45 @@ docker run -e OBS_PASSWORD=yourpassword ...
 
 ### Status
 
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/api/obs` | Get OBS status (version, streaming state) |
+| Method | Path       | Description                               |
+| ------ | ---------- | ----------------------------------------- |
+| GET    | `/api/obs` | Get OBS status (version, streaming state) |
+
+### Application Control
+
+| Method | Path             | Description           |
+| ------ | ---------------- | --------------------- |
+| POST   | `/api/obs/start` | Start OBS application |
+| POST   | `/api/obs/stop`  | Stop OBS application  |
 
 ### Initialization
 
-| Method | Path | Description |
-|--------|------|-------------|
-| POST | `/api/obs/init` | Initialize OBS client connection |
+| Method | Path            | Description                      |
+| ------ | --------------- | -------------------------------- |
+| POST   | `/api/obs/init` | Initialize OBS client connection |
 
 ### Streaming Control
 
-| Method | Path | Description |
-|--------|------|-------------|
-| POST | `/api/obs/start` | Start streaming |
-| POST | `/api/obs/stop` | Stop streaming |
+| Method | Path                       | Description     |
+| ------ | -------------------------- | --------------- |
+| POST   | `/api/obs/streaming/start` | Start streaming |
+| POST   | `/api/obs/streaming/stop`  | Stop streaming  |
 
 ### Data Overlay
 
-| Method | Path | Description |
-|--------|------|-------------|
-| POST | `/api/obs/data` | Update overlay text data |
+| Method | Path            | Description              |
+| ------ | --------------- | ------------------------ |
+| POST   | `/api/obs/data` | Update overlay text data |
 
 ## Usage Flow
 
 ```
-1. Start OBS and ensure WebSocket server is running
+1. Call POST /api/obs/start to start OBS application
 2. Call POST /api/obs/init to initialize connection
-3. Call POST /api/obs/start to start streaming
+3. Call POST /api/obs/streaming/start to start streaming
 4. Call POST /api/obs/data to update experiment data
-5. Call POST /api/obs/stop to stop streaming
+5. Call POST /api/obs/streaming/stop to stop streaming
+6. Call POST /api/obs/stop to stop OBS application
 ```
 
 ## Init Response Example
@@ -106,3 +124,4 @@ Overlay text format: `{hostname} {monkey_name} {trial_id} {correct_rate}% {start
 - Scene and Source cannot share the same name
 - Text source is automatically positioned at the bottom of the screen (1920x1080 assumed)
 - Only supports local OBS connection (`localhost:4455`)
+- If OBS is already running, `/api/obs/app/start` will track the existing process

--- a/internal/obs/README.zh_cn.md
+++ b/internal/obs/README.zh_cn.md
@@ -17,8 +17,11 @@ cogmoteGO 与 OBS Studio 的集成模块，用于在直播画面上叠加实验�
 ### CLI 配置
 
 ```bash
-# 交互式配置 scene、source 和密码
+# 交互式配置 scene、source 和安装方式
 cogmoteGO obs set
+
+# 设置 WebSocket 密码（存储在系统密钥环）
+cogmoteGO obs set-password
 
 # 查看当前配置状态
 cogmoteGO obs show
@@ -26,6 +29,13 @@ cogmoteGO obs show
 # 删除保存的密码
 cogmoteGO obs delete-password
 ```
+
+### 安装方式
+
+支持的安装方式：
+
+- `system`: 通过系统包管理器安装（默认）
+- `flatpak`: 通过 Flatpak 安装（`flatpak install com.obsproject.Studio`）
 
 ### Docker 环境
 
@@ -39,37 +49,45 @@ docker run -e OBS_PASSWORD=yourpassword ...
 
 ### 状态查询
 
-| 方法 | 路径 | 说明 |
-|------|------|------|
-| GET | `/api/obs` | 获取 OBS 状态 (版本、是否直播中) |
+| 方法 | 路径       | 说明                             |
+| ---- | ---------- | -------------------------------- |
+| GET  | `/api/obs` | 获取 OBS 状态 (版本、是否直播中) |
+
+### 应用控制
+
+| 方法 | 路径             | 说明              |
+| ---- | ---------------- | ----------------- |
+| POST | `/api/obs/start` | 启动 OBS 应用程序 |
+| POST | `/api/obs/stop`  | 关闭 OBS 应用程序 |
 
 ### 初始化
 
-| 方法 | 路径 | 说明 |
-|------|------|------|
+| 方法 | 路径            | 说明                  |
+| ---- | --------------- | --------------------- |
 | POST | `/api/obs/init` | 初始化 OBS 客户端连接 |
 
 ### 直播控制
 
-| 方法 | 路径 | 说明 |
-|------|------|------|
-| POST | `/api/obs/start` | 开始直播 |
-| POST | `/api/obs/stop` | 停止直播 |
+| 方法 | 路径                       | 说明     |
+| ---- | -------------------------- | -------- |
+| POST | `/api/obs/streaming/start` | 开始直播 |
+| POST | `/api/obs/streaming/stop`  | 停止直播 |
 
 ### 数据叠加
 
-| 方法 | 路径 | 说明 |
-|------|------|------|
+| 方法 | 路径            | 说明             |
+| ---- | --------------- | ---------------- |
 | POST | `/api/obs/data` | 更新叠加文本数据 |
 
 ## 使用流程
 
 ```
-1. 启动 OBS 并确保 WebSocket 服务器运行
+1. 调用 POST /api/obs/start 启动 OBS 应用程序
 2. 调用 POST /api/obs/init 初始化连接
-3. 调用 POST /api/obs/start 开始直播
+3. 调用 POST /api/obs/streaming/start 开始直播
 4. 调用 POST /api/obs/data 更新实验数据
-5. 调用 POST /api/obs/stop 停止直播
+5. 调用 POST /api/obs/streaming/stop 停止直播
+6. 调用 POST /api/obs/stop 关闭 OBS 应用程序
 ```
 
 ## Init 响应示例
@@ -106,3 +124,4 @@ POST `/api/obs/data` 请求体：
 - Scene 和 Source 不能使用相同名称
 - 文本源会自动定位在画面底部 (1920x1080 假设)
 - 仅支持连接本地 OBS (`localhost:4455`)
+- 如果 OBS 已在运行，`/api/obs/app/start` 会跟踪现有进程


### PR DESCRIPTION
- Add /api/obs/start and /api/obs/stop to control OBS application
- Add install_method config option (system/flatpak)
- Split CLI: obs set for config, obs set-password for password
- Reorganize streaming endpoints to /streaming/start and /streaming/stop