### PR TITLE
fix(obs): :bug: use polling to wait for OBS process exit on Unix

### DIFF
--- a/internal/obs/README.md
+++ b/internal/obs/README.md
@@ -124,4 +124,4 @@ Overlay text format: `{hostname} {monkey_name} {trial_id} {correct_rate}% {start
 - Scene and Source cannot share the same name
 - Text source is automatically positioned at the bottom of the screen (1920x1080 assumed)
 - Only supports local OBS connection (`localhost:4455`)
-- If OBS is already running, `/api/obs/app/start` will track the existing process
+- If OBS is already running, `/api/obs/start` will track the existing process

--- a/internal/obs/README.zh_cn.md
+++ b/internal/obs/README.zh_cn.md
@@ -124,4 +124,4 @@ POST `/api/obs/data` 请求体：
 - Scene 和 Source 不能使用相同名称
 - 文本源会自动定位在画面底部 (1920x1080 假设)
 - 仅支持连接本地 OBS (`localhost:4455`)
-- 如果 OBS 已在运行，`/api/obs/app/start` 会跟踪现有进程
+- 如果 OBS 已在运行，`/api/obs/start` 会跟踪现有进程


### PR DESCRIPTION
proc.Wait() only works for child processes. For external OBS processes, use Signal(0) polling to detect when the process has exited.