### PR TITLE
fix(obs): :bug: set process group for OBS subprocess

### DIFF
--- a/internal/obs/obs.go
+++ b/internal/obs/obs.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"runtime"
 	"strings"
+	"syscall"
 
 	"github.com/Ccccraz/cogmoteGO/internal/commonTypes"
 	"github.com/Ccccraz/cogmoteGO/internal/keyring"
@@ -105,6 +106,9 @@ func startObsProcess() error {
 
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setpgid: true,
+	}
 
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("failed to start OBS: %w", err)


### PR DESCRIPTION
- Add Setpgid: true to SysProcAttr to create new process group
- Enables killing entire process group for proper cleanup