### PR TITLE
fix(ci): :bug: use platform-specific build tags for process termination

### DIFF
--- a/internal/obs/obs.go
+++ b/internal/obs/obs.go
@@ -7,7 +7,6 @@ import (
 	"os/exec"
 	"runtime"
 	"strings"
-	"syscall"
 
 	"github.com/Ccccraz/cogmoteGO/internal/commonTypes"
 	"github.com/Ccccraz/cogmoteGO/internal/keyring"
@@ -106,9 +105,7 @@ func startObsProcess() error {
 
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	cmd.SysProcAttr = &syscall.SysProcAttr{
-		Setpgid: true,
-	}
+	setSysProcAttr(cmd)
 
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("failed to start OBS: %w", err)

--- a/internal/obs/proc_unix.go
+++ b/internal/obs/proc_unix.go
@@ -1,0 +1,14 @@
+//go:build !windows
+
+package obs
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func setSysProcAttr(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setpgid: true,
+	}
+}

--- a/internal/obs/proc_windows.go
+++ b/internal/obs/proc_windows.go
@@ -1,0 +1,8 @@
+//go:build windows
+
+package obs
+
+import "os/exec"
+
+func setSysProcAttr(cmd *exec.Cmd) {
+}


### PR DESCRIPTION
- Extract SysProcAttr setup into proc_unix.go and proc_windows.go
- Enables proper process group cleanup on Unix systems